### PR TITLE
PR to fix DB generation after hour was added to build filename

### DIFF
--- a/.github/build_db.py
+++ b/.github/build_db.py
@@ -59,7 +59,7 @@ def gather_urls():
             print('Discarded\n')
             continue
 
-        proc = subprocess.run(r'gh release view -R "MiSTer-unstable-nightlies/%s" unstable-builds --json "assets" 2> /tmp/stderr | jq -r ".assets[] | select(.name|test(\"^.*_unstable_[0-9]{8}_[0-9a-z]{4}[.]rbf$\")) | .url" | sort | tail -n 1' % name, shell=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+        proc = subprocess.run(r'gh release view -R "MiSTer-unstable-nightlies/%s" unstable-builds --json "assets" 2> /tmp/stderr | jq -r ".assets[] | select(.name|test(\"^.*_unstable_[0-9]{8}_([0-9]{2})?[0-9a-z]{4}[.]rbf$\")) | .url" | sort | tail -n 1' % name, shell=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
         url = proc.stdout.decode().strip()
         if url:
             all_urls.append(url)

--- a/db_unstable_nightlies_folder.json
+++ b/db_unstable_nightlies_folder.json
@@ -9,10 +9,10 @@
             "size": 3087108,
             "url": "https://github.com/MiSTer-unstable-nightlies/AcornAtom_MiSTer/releases/download/unstable-builds/AcornAtom_unstable_20220114_310b.rbf"
         },
-        "_Unstable/AcornElectron_unstable_20220125_f2a5.rbf": {
-            "hash": "1c9217305f79ab7275bf57e799934786",
-            "size": 3287372,
-            "url": "https://github.com/MiSTer-unstable-nightlies/AcornElectron_MiSTer/releases/download/unstable-builds/AcornElectron_unstable_20220125_f2a5.rbf"
+        "_Unstable/AcornElectron_unstable_20220203_229e92.rbf": {
+            "hash": "c44f65080e4184e49b6a386443b67ffa",
+            "size": 3297708,
+            "url": "https://github.com/MiSTer-unstable-nightlies/AcornElectron_MiSTer/releases/download/unstable-builds/AcornElectron_unstable_20220203_229e92.rbf"
         },
         "_Unstable/AliceMC10_unstable_20220111_eb36.rbf": {
             "hash": "637194170b38c598e5ffc333cb2beef2",
@@ -49,10 +49,10 @@
             "size": 4214284,
             "url": "https://github.com/MiSTer-unstable-nightlies/GBA_MiSTer/releases/download/unstable-builds/GBA_unstable_20211201_8948.rbf"
         },
-        "_Unstable/Gameboy_unstable_20220129_dd7e.rbf": {
-            "hash": "ab4dbe30c77dcdde913b23b21f9dc10c",
-            "size": 3786892,
-            "url": "https://github.com/MiSTer-unstable-nightlies/Gameboy_MiSTer/releases/download/unstable-builds/Gameboy_unstable_20220129_dd7e.rbf"
+        "_Unstable/Gameboy_unstable_20220202_23244d.rbf": {
+            "hash": "7697437f96210193fd3a84b950b2165c",
+            "size": 3812768,
+            "url": "https://github.com/MiSTer-unstable-nightlies/Gameboy_MiSTer/releases/download/unstable-builds/Gameboy_unstable_20220202_23244d.rbf"
         },
         "_Unstable/Genesis_unstable_20211221_a42c.rbf": {
             "hash": "27d1c5a54f6faf22efef415d15e0917c",
@@ -69,20 +69,20 @@
             "size": 4191920,
             "url": "https://github.com/MiSTer-unstable-nightlies/MegaCD_MiSTer/releases/download/unstable-builds/MegaCD_unstable_20210715_30ca.rbf"
         },
-        "_Unstable/NES_unstable_20220117_83b2.rbf": {
-            "hash": "3e9952787a48c110f3459034cfad2c17",
-            "size": 3169784,
-            "url": "https://github.com/MiSTer-unstable-nightlies/NES_MiSTer/releases/download/unstable-builds/NES_unstable_20220117_83b2.rbf"
+        "_Unstable/NES_unstable_20220202_2302a9.rbf": {
+            "hash": "a22a7d017cb71c111697ec92ac7c1167",
+            "size": 3209648,
+            "url": "https://github.com/MiSTer-unstable-nightlies/NES_MiSTer/releases/download/unstable-builds/NES_unstable_20220202_2302a9.rbf"
         },
         "_Unstable/NeoGeo_unstable_20220126_3e3e.rbf": {
             "hash": "cf48694232597d63690cd2733c7a39eb",
             "size": 3676880,
             "url": "https://github.com/MiSTer-unstable-nightlies/NeoGeo_MiSTer/releases/download/unstable-builds/NeoGeo_unstable_20220126_3e3e.rbf"
         },
-        "_Unstable/PSX_unstable_20220202_dd9b.rbf": {
-            "hash": "df805345e357432dfac99987e15fbb14",
-            "size": 3951488,
-            "url": "https://github.com/MiSTer-unstable-nightlies/PSX_MiSTer/releases/download/unstable-builds/PSX_unstable_20220202_dd9b.rbf"
+        "_Unstable/PSX_unstable_20220204_17ef53.rbf": {
+            "hash": "364731f3b98a14032235ee2cd48eb8d5",
+            "size": 3943000,
+            "url": "https://github.com/MiSTer-unstable-nightlies/PSX_MiSTer/releases/download/unstable-builds/PSX_unstable_20220204_17ef53.rbf"
         },
         "_Unstable/SMS_unstable_20220128_e5d7.rbf": {
             "hash": "2ee5367b69062800e925a5061091a509",
@@ -118,6 +118,6 @@
     "folders": {
         "_Unstable": {}
     },
-    "timestamp": 1643812983,
+    "timestamp": 1644001604,
     "zips": {}
 }


### PR DESCRIPTION
Update regex to include an optional 2 digit hour in the filename. 
`\"^.*_unstable_[0-9]{8}_([0-9]{2})?[0-9a-z]{4}[.]rbf$\"`